### PR TITLE
Remove name argument from agent contructor

### DIFF
--- a/seoulai_gym/envs/checkers/agents.py
+++ b/seoulai_gym/envs/checkers/agents.py
@@ -64,7 +64,6 @@ class Agent(ABC, Constants, Rules):
 class RandomAgent(Agent):
     def __init__(
         self,
-        name: str,
         ptype: int,
     ):
         """Initialize random agent.
@@ -73,6 +72,13 @@ class RandomAgent(Agent):
             name: name of agent.
             ptype: type of piece that agent is responsible for.
         """
+        if ptype == Constants().DARK:
+            name = "RandomAgentDark"
+        elif ptype == Constants().LIGHT:
+            name = "RandomAgentLight"
+        else:
+            raise ValueError
+
         super().__init__(name, ptype)
 
     def act(
@@ -117,14 +123,12 @@ class RandomAgent(Agent):
 class RandomAgentLight(RandomAgent):
     def __init__(
         self,
-        name: str,
     ):
-        super().__init__(name, Constants().LIGHT)
+        super().__init__(Constants().LIGHT)
 
 
 class RandomAgentDark(RandomAgent):
     def __init__(
         self,
-        name: str,
     ):
-        super().__init__(name, Constants().DARK)
+        super().__init__(Constants().DARK)


### PR DESCRIPTION
Previously, agent accepted `name` argument, but for purposes of Seoul AI Hackathon, `name` argument is removed. Note that name of agent still has to be setup in constructor e.g.:

```python
class MyAwesomeAgent(Agent):
  def __init__(
      self,
      ptype: int,
  ):
    super().__init__("MyAwesomeAgent", ptype)  # <- HERE
```